### PR TITLE
ci: add unified/gate job for org ruleset compliance

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1,0 +1,36 @@
+name: Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  gate:
+    name: unified / gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Build
+        run: cargo build --workspace --all-features
+
+      - name: Test
+        run: cargo test --workspace --all-features


### PR DESCRIPTION
## Summary
- Adds a new `.github/workflows/gate.yml` workflow with a single `unified / gate` job
- The gate job runs fmt check, clippy, build, and full workspace tests on push/PR to main
- Satisfies the org-level branch protection ruleset that requires a `unified / gate` status check to pass before merge

## Context
The repo has 8 separate workflow files (benchmark, clippy-lint, cross-platform, jidoka-gates, nightly, post-release, security, stress) but none produce a status check named `unified / gate` which the org ruleset requires. This adds that missing check.

## Test plan
- [ ] Verify the `unified / gate` check appears on this PR's status checks
- [ ] Confirm fmt, clippy, build, and test steps all pass
- [ ] Confirm branch protection ruleset recognizes the new check name

🤖 Generated with [Claude Code](https://claude.com/claude-code)