### PR TITLE
fix: update aws-lc-sys to resolve 5 RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",

--- a/src/generated_contracts.rs
+++ b/src/generated_contracts.rs
@@ -12,8 +12,10 @@ macro_rules! contract_pre_absolute_position_add {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract absolute_position_add: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract absolute_position_add: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -26,10 +28,11 @@ macro_rules! contract_pre_gelu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract gelu: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract gelu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract gelu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract gelu: precondition violated — x.len() > 0");
     }};
 }
 
@@ -39,10 +42,11 @@ macro_rules! contract_pre_relu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract relu: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract relu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract relu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract relu: precondition violated — x.len() > 0");
     }};
 }
 
@@ -52,10 +56,11 @@ macro_rules! contract_pre_silu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract silu: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract silu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract silu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract silu: precondition violated — x.len() > 0");
     }};
 }
 
@@ -68,10 +73,14 @@ macro_rules! contract_pre_entropy_score {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract entropy_score: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract entropy_score: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract entropy_score: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract entropy_score: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -81,10 +90,14 @@ macro_rules! contract_pre_margin_score {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract margin_score: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract margin_score: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract margin_score: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract margin_score: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -94,10 +107,14 @@ macro_rules! contract_pre_qbc_score {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract qbc_score: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract qbc_score: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract qbc_score: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract qbc_score: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -123,8 +140,10 @@ macro_rules! contract_pre_adam_moments {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract adam_moments: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract adam_moments: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -134,8 +153,10 @@ macro_rules! contract_pre_adam_variance {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract adam_variance: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract adam_variance: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -145,8 +166,10 @@ macro_rules! contract_pre_bias_correction {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract bias_correction: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract bias_correction: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -156,8 +179,10 @@ macro_rules! contract_pre_weight_update {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract weight_update: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract weight_update: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -170,8 +195,10 @@ macro_rules! contract_pre_alibi_bias {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract alibi_bias: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract alibi_bias: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -181,8 +208,10 @@ macro_rules! contract_pre_alibi_slopes {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract alibi_slopes: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract alibi_slopes: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -211,8 +240,10 @@ macro_rules! contract_pre_detect_regression {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract detect_regression: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract detect_regression: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -222,8 +253,10 @@ macro_rules! contract_pre_format_report {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract format_report: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract format_report: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -233,8 +266,10 @@ macro_rules! contract_pre_parse_playbook {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract parse_playbook: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract parse_playbook: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -244,8 +279,10 @@ macro_rules! contract_pre_serialize_roundtrip {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract serialize_roundtrip: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract serialize_roundtrip: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -255,8 +292,10 @@ macro_rules! contract_pre_validate_schema {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract validate_schema: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract validate_schema: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -269,8 +308,10 @@ macro_rules! contract_pre_arch_constraint_lookup {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract arch_constraint_lookup: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract arch_constraint_lookup: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -283,8 +324,10 @@ macro_rules! contract_pre_constraint_matrix_exhaustiveness {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract constraint_matrix_exhaustiveness: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract constraint_matrix_exhaustiveness: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -294,8 +337,10 @@ macro_rules! contract_pre_role_mapping {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract role_mapping: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract role_mapping: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -305,8 +350,10 @@ macro_rules! contract_pre_weight_completeness {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract weight_completeness: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract weight_completeness: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -319,10 +366,14 @@ macro_rules! contract_pre_ar_forecast {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ar_forecast: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract ar_forecast: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ar_forecast: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract ar_forecast: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -332,10 +383,14 @@ macro_rules! contract_pre_differencing {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract differencing: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract differencing: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract differencing: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract differencing: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -358,10 +413,14 @@ macro_rules! contract_pre_ma_filter {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ma_filter: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract ma_filter: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ma_filter: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract ma_filter: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -374,8 +433,7 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract identity: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract identity: precondition violated — q.len() > 0");
     }};
 }
 
@@ -388,8 +446,10 @@ macro_rules! contract_pre_attention {
     () => {{}};
     ($input:expr) => {{
         let query = &$input;
-        debug_assert!(query.len() > 0,
-            "Contract attention: precondition violated — query.len() > 0");
+        debug_assert!(
+            query.len() > 0,
+            "Contract attention: precondition violated — query.len() > 0"
+        );
     }};
 }
 
@@ -398,7 +458,10 @@ macro_rules! contract_pre_attention {
 macro_rules! contract_post_attention {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.iter().all(|v| v.is_finite()), "Contract attention: postcondition violated — result.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            _contract_result.iter().all(|v| v.is_finite()),
+            "Contract attention: postcondition violated — result.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -421,8 +484,10 @@ macro_rules! contract_pre_attention_entropy {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract attention_entropy: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract attention_entropy: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -432,8 +497,10 @@ macro_rules! contract_pre_numerical_stability {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract numerical_stability: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract numerical_stability: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -443,8 +510,10 @@ macro_rules! contract_pre_scaled_dot_product {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract scaled_dot_product: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract scaled_dot_product: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -467,10 +536,14 @@ macro_rules! contract_pre_softmax_saturation {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract softmax_saturation: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract softmax_saturation: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract softmax_saturation: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            x.len() > 0,
+            "Contract softmax_saturation: precondition violated — x.len() > 0"
+        );
     }};
 }
 
@@ -480,8 +553,10 @@ macro_rules! contract_pre_variance_preservation {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract variance_preservation: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract variance_preservation: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -494,8 +569,7 @@ macro_rules! contract_pre_dot_product {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract dot_product: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract dot_product: precondition violated — a.len() > 0");
     }};
 }
 
@@ -505,8 +579,10 @@ macro_rules! contract_pre_fma_accumulation {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract fma_accumulation: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract fma_accumulation: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -519,10 +595,14 @@ macro_rules! contract_pre_garbage_oracle {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract garbage_oracle: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract garbage_oracle: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract garbage_oracle: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract garbage_oracle: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -532,10 +612,14 @@ macro_rules! contract_pre_gpu_threshold {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract gpu_threshold: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract gpu_threshold: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract gpu_threshold: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract gpu_threshold: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -574,8 +658,10 @@ macro_rules! contract_pre_batch_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract batch_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract batch_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -585,8 +671,10 @@ macro_rules! contract_pre_gradient_accumulation {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract gradient_accumulation: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract gradient_accumulation: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -596,8 +684,10 @@ macro_rules! contract_pre_gradient_clipping {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract gradient_clipping: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract gradient_clipping: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -610,8 +700,10 @@ macro_rules! contract_pre_batched_beam_projection {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract batched_beam_projection: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract batched_beam_projection: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -621,8 +713,10 @@ macro_rules! contract_pre_beam_selection {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract beam_selection: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract beam_selection: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -632,8 +726,10 @@ macro_rules! contract_pre_sequential_beam_projection {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract sequential_beam_projection: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract sequential_beam_projection: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -643,8 +739,10 @@ macro_rules! contract_pre_termination {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract termination: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract termination: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -657,10 +755,14 @@ macro_rules! contract_pre_batchnorm_eval {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract batchnorm_eval: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract batchnorm_eval: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract batchnorm_eval: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract batchnorm_eval: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -683,10 +785,14 @@ macro_rules! contract_pre_running_stats {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract running_stats: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract running_stats: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract running_stats: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract running_stats: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -699,10 +805,14 @@ macro_rules! contract_pre_blr_predict {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract blr_predict: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract blr_predict: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract blr_predict: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract blr_predict: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -754,10 +864,14 @@ macro_rules! contract_pre_bias_add {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bias_add: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract bias_add: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract bias_add: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract bias_add: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -770,8 +884,10 @@ macro_rules! contract_pre_bidirectional_attention {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract bidirectional_attention: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract bidirectional_attention: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -784,8 +900,10 @@ macro_rules! contract_pre_composite_hash {
     () => {{}};
     ($input:expr) => {{
         let parts = &$input;
-        debug_assert!(parts.len() > 0,
-            "Contract composite_hash: precondition violated — parts.len() > 0");
+        debug_assert!(
+            parts.len() > 0,
+            "Contract composite_hash: precondition violated — parts.len() > 0"
+        );
     }};
 }
 
@@ -804,10 +922,14 @@ macro_rules! contract_pre_hash_string {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(!input.is_empty(),
-            "Contract hash_string: precondition violated — !input.is_empty()");
-        debug_assert!(input.len() <= 1_073_741_824,
-            "Contract hash_string: precondition violated — input.len() <= 1_073_741_824");
+        debug_assert!(
+            !input.is_empty(),
+            "Contract hash_string: precondition violated — !input.is_empty()"
+        );
+        debug_assert!(
+            input.len() <= 1_073_741_824,
+            "Contract hash_string: precondition violated — input.len() <= 1_073_741_824"
+        );
     }};
 }
 
@@ -842,8 +964,10 @@ macro_rules! contract_pre_merge_rule {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract merge_rule: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract merge_rule: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -856,8 +980,10 @@ macro_rules! contract_pre_builder_pattern {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract builder_pattern: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract builder_pattern: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -909,10 +1035,14 @@ macro_rules! contract_pre_platt_scaling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract platt_scaling: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract platt_scaling: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract platt_scaling: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract platt_scaling: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -938,8 +1068,10 @@ macro_rules! contract_pre_classifier_weight_shape {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract classifier_weight_shape: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract classifier_weight_shape: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -949,8 +1081,7 @@ macro_rules! contract_pre_label_bounds {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract label_bounds: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract label_bounds: precondition violated — a.len() > 0");
     }};
 }
 
@@ -960,8 +1091,7 @@ macro_rules! contract_pre_logit_shape {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract logit_shape: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract logit_shape: precondition violated — a.len() > 0");
     }};
 }
 
@@ -971,10 +1101,11 @@ macro_rules! contract_pre_softmax_sum {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract softmax_sum: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract softmax_sum: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract softmax_sum: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract softmax_sum: precondition violated — x.len() > 0");
     }};
 }
 
@@ -987,8 +1118,10 @@ macro_rules! contract_pre_embedding_extraction {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract embedding_extraction: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract embedding_extraction: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -1019,8 +1152,10 @@ macro_rules! contract_pre_covariance_update {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract covariance_update: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract covariance_update: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -1030,8 +1165,10 @@ macro_rules! contract_pre_mean_update {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract mean_update: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract mean_update: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -1041,8 +1178,10 @@ macro_rules! contract_pre_sample {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract sample: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract sample: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -1055,8 +1194,10 @@ macro_rules! contract_pre_tokenizer_adequacy {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract tokenizer_adequacy: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract tokenizer_adequacy: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1099,8 +1240,10 @@ macro_rules! contract_pre_aggregate_score {
     () => {{}};
     ($input:expr) => {{
         let checks = &$input;
-        debug_assert!(checks.len() > 0,
-            "Contract aggregate_score: precondition violated — checks.len() > 0");
+        debug_assert!(
+            checks.len() > 0,
+            "Contract aggregate_score: precondition violated — checks.len() > 0"
+        );
     }};
 }
 
@@ -1122,8 +1265,10 @@ macro_rules! contract_pre_configuration {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract configuration: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract configuration: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1132,7 +1277,10 @@ macro_rules! contract_pre_configuration {
 macro_rules! contract_post_configuration {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.len() > 0, "Contract configuration: postcondition violated — result.len() > 0");
+        debug_assert!(
+            _contract_result.len() > 0,
+            "Contract configuration: postcondition violated — result.len() > 0"
+        );
     }};
 }
 
@@ -1194,8 +1342,10 @@ macro_rules! contract_pre_decode_degradation {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract decode_degradation: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract decode_degradation: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1232,8 +1382,10 @@ macro_rules! contract_pre_token_budget {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract token_budget: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract token_budget: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1246,8 +1398,7 @@ macro_rules! contract_pre_conv1d {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract conv1d: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract conv1d: precondition violated — a.len() > 0");
     }};
 }
 
@@ -1260,8 +1411,10 @@ macro_rules! contract_pre_chatml_format {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract chatml_format: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract chatml_format: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1271,8 +1424,10 @@ macro_rules! contract_pre_conversation_types {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract conversation_types: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract conversation_types: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1282,8 +1437,10 @@ macro_rules! contract_pre_quality_gate {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract quality_gate: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract quality_gate: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1296,10 +1453,11 @@ macro_rules! contract_pre_current_path {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract current_path: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract current_path: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract current_path: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract current_path: precondition violated — x.len() > 0");
     }};
 }
 
@@ -1309,10 +1467,11 @@ macro_rules! contract_pre_speedup_bound {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract speedup_bound: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract speedup_bound: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract speedup_bound: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract speedup_bound: precondition violated — x.len() > 0");
     }};
 }
 
@@ -1322,10 +1481,11 @@ macro_rules! contract_pre_target_path {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract target_path: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract target_path: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract target_path: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract target_path: precondition violated — x.len() > 0");
     }};
 }
 
@@ -1338,10 +1498,14 @@ macro_rules! contract_pre_l1_tiling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract l1_tiling: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract l1_tiling: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract l1_tiling: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract l1_tiling: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1351,10 +1515,14 @@ macro_rules! contract_pre_rayon_overhead {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract rayon_overhead: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract rayon_overhead: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract rayon_overhead: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract rayon_overhead: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1367,10 +1535,14 @@ macro_rules! contract_pre_cross_entropy {
     () => {{}};
     ($input:expr) => {{
         let logits = &$input;
-        debug_assert!(logits.len() > 0,
-            "Contract cross_entropy: precondition violated — logits.len() > 0");
-        debug_assert!(logits.iter().all(|v| v.is_finite()),
-            "Contract cross_entropy: precondition violated — logits.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            logits.len() > 0,
+            "Contract cross_entropy: precondition violated — logits.len() > 0"
+        );
+        debug_assert!(
+            logits.iter().all(|v| v.is_finite()),
+            "Contract cross_entropy: precondition violated — logits.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1379,8 +1551,14 @@ macro_rules! contract_pre_cross_entropy {
 macro_rules! contract_post_cross_entropy {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.is_finite(), "Contract cross_entropy: postcondition violated — result.is_finite()");
-        debug_assert!(*_contract_result >= 0.0, "Contract cross_entropy: postcondition violated — result >= 0.0");
+        debug_assert!(
+            _contract_result.is_finite(),
+            "Contract cross_entropy: postcondition violated — result.is_finite()"
+        );
+        debug_assert!(
+            *_contract_result >= 0.0,
+            "Contract cross_entropy: postcondition violated — result >= 0.0"
+        );
     }};
 }
 
@@ -1400,10 +1578,11 @@ macro_rules! contract_pre_log_softmax {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract log_softmax: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract log_softmax: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract log_softmax: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract log_softmax: precondition violated — x.len() > 0");
     }};
 }
 
@@ -1434,8 +1613,10 @@ macro_rules! contract_pre_weight_roundtrip {
     () => {{}};
     ($input:expr) => {{
         let weights = &$input;
-        debug_assert!(weights.len() > 0,
-            "Contract weight_roundtrip: precondition violated — weights.len() > 0");
+        debug_assert!(
+            weights.len() > 0,
+            "Contract weight_roundtrip: precondition violated — weights.len() > 0"
+        );
     }};
 }
 
@@ -1469,10 +1650,14 @@ macro_rules! contract_pre_gini_impurity {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract gini_impurity: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract gini_impurity: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract gini_impurity: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract gini_impurity: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1482,10 +1667,14 @@ macro_rules! contract_pre_gini_split {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract gini_split: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract gini_split: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract gini_split: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract gini_split: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1495,10 +1684,14 @@ macro_rules! contract_pre_mse_split {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract mse_split: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract mse_split: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract mse_split: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract mse_split: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1508,10 +1701,14 @@ macro_rules! contract_pre_prediction {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract prediction: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract prediction: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract prediction: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract prediction: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1524,8 +1721,10 @@ macro_rules! contract_pre_display_format {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract display_format: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract display_format: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1534,7 +1733,10 @@ macro_rules! contract_pre_display_format {
 macro_rules! contract_post_display_format {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.len() > 0, "Contract display_format: postcondition violated — result.len() > 0");
+        debug_assert!(
+            _contract_result.len() > 0,
+            "Contract display_format: postcondition violated — result.len() > 0"
+        );
     }};
 }
 
@@ -1564,7 +1766,10 @@ macro_rules! contract_pre_render {
 macro_rules! contract_post_render {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.len() > 0, "Contract render: postcondition violated — result.len() > 0");
+        debug_assert!(
+            _contract_result.len() > 0,
+            "Contract render: postcondition violated — result.len() > 0"
+        );
     }};
 }
 
@@ -1587,8 +1792,10 @@ macro_rules! contract_pre_gradient_allreduce {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract gradient_allreduce: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract gradient_allreduce: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -1611,10 +1818,14 @@ macro_rules! contract_pre_sharding {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract sharding: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract sharding: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract sharding: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract sharding: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1624,10 +1835,14 @@ macro_rules! contract_pre_swiglu_ffn {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract swiglu_ffn: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract swiglu_ffn: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract swiglu_ffn: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract swiglu_ffn: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -1637,8 +1852,10 @@ macro_rules! contract_pre_weighted_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract weighted_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract weighted_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -1651,8 +1868,10 @@ macro_rules! contract_pre_dpo_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract dpo_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract dpo_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -1662,8 +1881,10 @@ macro_rules! contract_pre_implicit_reward {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract implicit_reward: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract implicit_reward: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -1673,8 +1894,10 @@ macro_rules! contract_pre_log_ratio {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract log_ratio: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract log_ratio: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -1696,8 +1919,10 @@ macro_rules! contract_pre_min_samples_guard {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract min_samples_guard: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract min_samples_guard: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -1707,8 +1932,10 @@ macro_rules! contract_pre_performance_drift {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract performance_drift: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract performance_drift: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1718,8 +1945,10 @@ macro_rules! contract_pre_univariate_drift {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract univariate_drift: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract univariate_drift: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1732,10 +1961,11 @@ macro_rules! contract_pre_dropout_eval {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract dropout_eval: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract dropout_eval: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract dropout_eval: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract dropout_eval: precondition violated — x.len() > 0");
     }};
 }
 
@@ -1745,10 +1975,11 @@ macro_rules! contract_pre_dropout_train {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract dropout_train: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract dropout_train: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract dropout_train: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract dropout_train: precondition violated — x.len() > 0");
     }};
 }
 
@@ -1761,8 +1992,10 @@ macro_rules! contract_pre_embedding_lookup {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract embedding_lookup: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract embedding_lookup: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -1772,10 +2005,14 @@ macro_rules! contract_pre_embedding_norm {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract embedding_norm: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract embedding_norm: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract embedding_norm: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract embedding_norm: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1785,8 +2022,10 @@ macro_rules! contract_pre_logit_temperature {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract logit_temperature: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract logit_temperature: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -1796,8 +2035,10 @@ macro_rules! contract_pre_tied_weights {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract tied_weights: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract tied_weights: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -1807,8 +2048,10 @@ macro_rules! contract_pre_unembedding_projection {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract unembedding_projection: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract unembedding_projection: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -1818,8 +2061,10 @@ macro_rules! contract_pre_vocabulary_bounds {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract vocabulary_bounds: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract vocabulary_bounds: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1863,8 +2108,10 @@ macro_rules! contract_pre_cls_pooling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract cls_pooling: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract cls_pooling: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1874,8 +2121,10 @@ macro_rules! contract_pre_encoder_layer {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract encoder_layer: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract encoder_layer: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1888,8 +2137,10 @@ macro_rules! contract_pre_emit_posix {
     () => {{}};
     ($input:expr) => {{
         let _contract_input = &$input;
-        debug_assert!(!_contract_input.is_empty(),
-            "Contract emit_posix: precondition violated — !input.is_empty()");
+        debug_assert!(
+            !_contract_input.is_empty(),
+            "Contract emit_posix: precondition violated — !input.is_empty()"
+        );
     }};
 }
 
@@ -1899,8 +2150,10 @@ macro_rules! contract_pre_emit_purified {
     () => {{}};
     ($input:expr) => {{
         let _contract_input = &$input;
-        debug_assert!(!_contract_input.is_empty(),
-            "Contract emit_purified: precondition violated — !input.is_empty()");
+        debug_assert!(
+            !_contract_input.is_empty(),
+            "Contract emit_purified: precondition violated — !input.is_empty()"
+        );
     }};
 }
 
@@ -1910,8 +2163,10 @@ macro_rules! contract_pre_roundtrip {
     () => {{}};
     ($input:expr) => {{
         let _contract_input = &$input;
-        debug_assert!(!_contract_input.is_empty(),
-            "Contract roundtrip: precondition violated — !input.is_empty()");
+        debug_assert!(
+            !_contract_input.is_empty(),
+            "Contract roundtrip: precondition violated — !input.is_empty()"
+        );
     }};
 }
 
@@ -1924,8 +2179,10 @@ macro_rules! contract_pre_error_handling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract error_handling: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract error_handling: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1934,7 +2191,10 @@ macro_rules! contract_pre_error_handling {
 macro_rules! contract_post_error_handling {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.len() > 0, "Contract error_handling: postcondition violated — result.len() > 0");
+        debug_assert!(
+            _contract_result.len() > 0,
+            "Contract error_handling: postcondition violated — result.len() > 0"
+        );
     }};
 }
 
@@ -1978,8 +2238,10 @@ macro_rules! contract_pre_f16_to_f32_bias {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract f16_to_f32_bias: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract f16_to_f32_bias: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -1989,8 +2251,10 @@ macro_rules! contract_pre_roundtrip {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract roundtrip: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract roundtrip: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2017,8 +2281,10 @@ macro_rules! contract_pre_element_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract element_count: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract element_count: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2028,10 +2294,14 @@ macro_rules! contract_pre_identity_1d {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract identity_1d: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract identity_1d: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract identity_1d: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract identity_1d: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2041,8 +2311,10 @@ macro_rules! contract_pre_name_bijection {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract name_bijection: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract name_bijection: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2052,8 +2324,10 @@ macro_rules! contract_pre_transpose_involution {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract transpose_involution: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract transpose_involution: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -2066,8 +2340,10 @@ macro_rules! contract_pre_e4m3_encode {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract e4m3_encode: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract e4m3_encode: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2077,8 +2353,10 @@ macro_rules! contract_pre_e5m2_encode {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract e5m2_encode: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract e5m2_encode: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2088,8 +2366,10 @@ macro_rules! contract_pre_roundtrip {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract roundtrip: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract roundtrip: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2102,8 +2382,7 @@ macro_rules! contract_pre_fused_qkv {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract fused_qkv: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract fused_qkv: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2113,8 +2392,7 @@ macro_rules! contract_pre_separate_qkv {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract separate_qkv: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract separate_qkv: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2124,8 +2402,7 @@ macro_rules! contract_pre_shared_q8_qkv {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract shared_q8_qkv: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract shared_q8_qkv: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2138,10 +2415,11 @@ macro_rules! contract_pre_decay {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract decay: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract decay: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract decay: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract decay: precondition violated — x.len() > 0");
     }};
 }
 
@@ -2151,10 +2429,11 @@ macro_rules! contract_pre_delta {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract delta: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract delta: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(input.len() > 0, "Contract delta: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract delta: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2177,10 +2456,11 @@ macro_rules! contract_pre_read {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract read: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract read: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(input.len() > 0, "Contract read: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract read: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2190,10 +2470,11 @@ macro_rules! contract_pre_write {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract write: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract write: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(input.len() > 0, "Contract write: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract write: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2245,8 +2526,10 @@ macro_rules! contract_pre_training_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract training_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract training_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -2259,10 +2542,11 @@ macro_rules! contract_pre_gelu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract gelu: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract gelu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract gelu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract gelu: precondition violated — x.len() > 0");
     }};
 }
 
@@ -2272,10 +2556,14 @@ macro_rules! contract_pre_gelu_tanh_approx {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract gelu_tanh_approx: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract gelu_tanh_approx: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract gelu_tanh_approx: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            x.len() > 0,
+            "Contract gelu_tanh_approx: precondition violated — x.len() > 0"
+        );
     }};
 }
 
@@ -2310,8 +2598,10 @@ macro_rules! contract_pre_shared_memory_per_tile {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract shared_memory_per_tile: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract shared_memory_per_tile: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -2321,8 +2611,10 @@ macro_rules! contract_pre_tiled_gemm_arithmetic_intensity {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract tiled_gemm_arithmetic_intensity: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract tiled_gemm_arithmetic_intensity: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -2332,8 +2624,10 @@ macro_rules! contract_pre_unrolled_instruction_ratio {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract unrolled_instruction_ratio: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract unrolled_instruction_ratio: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -2358,10 +2652,14 @@ macro_rules! contract_pre_binomial_link {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract binomial_link: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract binomial_link: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract binomial_link: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract binomial_link: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2371,10 +2669,14 @@ macro_rules! contract_pre_gamma_link {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract gamma_link: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract gamma_link: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract gamma_link: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract gamma_link: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2384,10 +2686,14 @@ macro_rules! contract_pre_irls_fit {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract irls_fit: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract irls_fit: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract irls_fit: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract irls_fit: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2397,10 +2703,14 @@ macro_rules! contract_pre_poisson_link {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract poisson_link: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract poisson_link: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract poisson_link: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract poisson_link: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2452,8 +2762,10 @@ macro_rules! contract_pre_context_health {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract context_health: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract context_health: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2472,8 +2784,10 @@ macro_rules! contract_pre_culink_skip {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract culink_skip: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract culink_skip: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2483,8 +2797,10 @@ macro_rules! contract_pre_fp8_architecture_guard {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract fp8_architecture_guard: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract fp8_architecture_guard: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2497,8 +2813,10 @@ macro_rules! contract_pre_brick_ordering {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract brick_ordering: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract brick_ordering: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2508,8 +2826,10 @@ macro_rules! contract_pre_graph_disable {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract graph_disable: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract graph_disable: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2519,8 +2839,10 @@ macro_rules! contract_pre_report_completeness {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract report_completeness: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract report_completeness: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2530,8 +2852,10 @@ macro_rules! contract_pre_report_denominator {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract report_denominator: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract report_denominator: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2541,8 +2865,10 @@ macro_rules! contract_pre_report_fidelity {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract report_fidelity: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract report_fidelity: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2552,8 +2878,10 @@ macro_rules! contract_pre_report_metadata {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract report_metadata: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract report_metadata: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2563,8 +2891,10 @@ macro_rules! contract_pre_sync_verification {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract sync_verification: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract sync_verification: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2574,8 +2904,10 @@ macro_rules! contract_pre_token_accounting {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract token_accounting: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract token_accounting: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2585,8 +2917,10 @@ macro_rules! contract_pre_wall_coverage {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract wall_coverage: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract wall_coverage: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2599,8 +2933,10 @@ macro_rules! contract_pre_backend_priority {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract backend_priority: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract backend_priority: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2610,8 +2946,10 @@ macro_rules! contract_pre_bandwidth_bound_theorem {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bandwidth_bound_theorem: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract bandwidth_bound_theorem: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2621,8 +2959,10 @@ macro_rules! contract_pre_jit_compilation_correctness {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract jit_compilation_correctness: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract jit_compilation_correctness: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2632,8 +2972,10 @@ macro_rules! contract_pre_multi_backend_parity {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract multi_backend_parity: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract multi_backend_parity: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2646,8 +2988,10 @@ macro_rules! contract_pre_pcie_overhead {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract pcie_overhead: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract pcie_overhead: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2657,8 +3001,10 @@ macro_rules! contract_pre_throughput_target {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract throughput_target: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract throughput_target: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2671,8 +3017,7 @@ macro_rules! contract_pre_gqa {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract gqa: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract gqa: precondition violated — q.len() > 0");
     }};
 }
 
@@ -2742,8 +3087,7 @@ macro_rules! contract_pre_conv1d_causal {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract conv1d_causal: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract conv1d_causal: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2753,10 +3097,14 @@ macro_rules! contract_pre_head_grouping {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract head_grouping: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract head_grouping: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract head_grouping: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract head_grouping: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2792,10 +3140,14 @@ macro_rules! contract_pre_linear_no_softmax {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract linear_no_softmax: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract linear_no_softmax: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract linear_no_softmax: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            x.len() > 0,
+            "Contract linear_no_softmax: precondition violated — x.len() > 0"
+        );
     }};
 }
 
@@ -2805,10 +3157,14 @@ macro_rules! contract_pre_linear_shapes {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract linear_shapes: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract linear_shapes: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract linear_shapes: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract linear_shapes: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -2821,8 +3177,7 @@ macro_rules! contract_pre_fastica {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract fastica: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract fastica: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2832,8 +3187,7 @@ macro_rules! contract_pre_mixing {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract mixing: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract mixing: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2843,8 +3197,7 @@ macro_rules! contract_pre_unmixing {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract unmixing: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract unmixing: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2857,8 +3210,10 @@ macro_rules! contract_pre_decode_step {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract decode_step: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract decode_step: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2888,8 +3243,10 @@ macro_rules! contract_pre_layer_composition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract layer_composition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract layer_composition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -2920,8 +3277,7 @@ macro_rules! contract_pre_dequant_dot {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract dequant_dot: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract dequant_dot: precondition violated — a.len() > 0");
     }};
 }
 
@@ -2931,8 +3287,10 @@ macro_rules! contract_pre_per_row_scale {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract per_row_scale: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract per_row_scale: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2942,8 +3300,10 @@ macro_rules! contract_pre_quantize {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract quantize: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract quantize: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2956,8 +3316,10 @@ macro_rules! contract_pre_iterator {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract iterator: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract iterator: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2970,8 +3332,7 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract identity: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract identity: precondition violated — q.len() > 0");
     }};
 }
 
@@ -2984,8 +3345,10 @@ macro_rules! contract_pre_bsum_budget {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bsum_budget: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract bsum_budget: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -2995,8 +3358,10 @@ macro_rules! contract_pre_per_layer_decomposition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract per_layer_decomposition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract per_layer_decomposition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -3006,8 +3371,10 @@ macro_rules! contract_pre_per_token_launches {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract per_token_launches: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract per_token_launches: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3020,10 +3387,14 @@ macro_rules! contract_pre_assignment {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract assignment: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract assignment: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract assignment: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract assignment: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3033,10 +3404,14 @@ macro_rules! contract_pre_objective {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract objective: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract objective: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract objective: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract objective: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3119,8 +3494,10 @@ macro_rules! contract_pre_per_token_per_layer {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract per_token_per_layer: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract per_token_per_layer: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3163,10 +3540,11 @@ macro_rules! contract_pre_layernorm {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.len() > 0,
-            "Contract layernorm: precondition violated — x.len() > 0");
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract layernorm: precondition violated — x.iter().all(|v| v.is_finite())");
+        debug_assert!(x.len() > 0, "Contract layernorm: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract layernorm: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3175,7 +3553,10 @@ macro_rules! contract_pre_layernorm {
 macro_rules! contract_post_layernorm {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.iter().all(|v| v.is_finite()), "Contract layernorm: postcondition violated — result.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            _contract_result.iter().all(|v| v.is_finite()),
+            "Contract layernorm: postcondition violated — result.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3195,10 +3576,14 @@ macro_rules! contract_pre_statistics {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract statistics: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract statistics: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract statistics: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract statistics: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3211,8 +3596,10 @@ macro_rules! contract_pre_line_search {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract line_search: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract line_search: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3222,8 +3609,10 @@ macro_rules! contract_pre_secant_condition {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract secant_condition: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract secant_condition: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3233,8 +3622,10 @@ macro_rules! contract_pre_two_loop_recursion {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract two_loop_recursion: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract two_loop_recursion: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3247,8 +3638,10 @@ macro_rules! contract_pre_position_embedding {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract position_embedding: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract position_embedding: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -3287,10 +3680,14 @@ macro_rules! contract_pre_ols_predict {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ols_predict: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract ols_predict: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ols_predict: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract ols_predict: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3316,8 +3713,10 @@ macro_rules! contract_pre_linear_probe {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract linear_probe: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract linear_probe: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3355,10 +3754,14 @@ macro_rules! contract_pre_dare_unbiased {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract dare_unbiased: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract dare_unbiased: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract dare_unbiased: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract dare_unbiased: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3368,10 +3771,14 @@ macro_rules! contract_pre_eckart_young {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract eckart_young: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract eckart_young: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract eckart_young: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract eckart_young: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3381,10 +3788,14 @@ macro_rules! contract_pre_lora_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract lora_shape: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract lora_shape: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract lora_shape: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract lora_shape: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3407,10 +3818,14 @@ macro_rules! contract_pre_task_vector {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract task_vector: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract task_vector: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract task_vector: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract task_vector: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3435,8 +3850,10 @@ macro_rules! contract_pre_bce {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract bce: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract bce: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3446,8 +3863,10 @@ macro_rules! contract_pre_huber {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract huber: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract huber: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3457,8 +3876,10 @@ macro_rules! contract_pre_l1_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract l1_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract l1_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3468,8 +3889,10 @@ macro_rules! contract_pre_mse_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract mse_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract mse_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3479,8 +3902,10 @@ macro_rules! contract_pre_nll {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract nll: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract nll: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3490,8 +3915,10 @@ macro_rules! contract_pre_smooth_l1 {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract smooth_l1: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract smooth_l1: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3512,7 +3939,10 @@ macro_rules! contract_pre_matmul {
 macro_rules! contract_post_matmul {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.iter().all(|v| v.is_finite()), "Contract matmul: postcondition violated — result.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            _contract_result.iter().all(|v| v.is_finite()),
+            "Contract matmul: postcondition violated — result.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3532,8 +3962,10 @@ macro_rules! contract_pre_quantized_dot {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract quantized_dot: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract quantized_dot: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3546,8 +3978,10 @@ macro_rules! contract_pre_bounds_safety {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bounds_safety: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract bounds_safety: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3557,8 +3991,10 @@ macro_rules! contract_pre_drop_safety {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract drop_safety: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract drop_safety: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3568,8 +4004,10 @@ macro_rules! contract_pre_escape_analysis {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract escape_analysis: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract escape_analysis: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3579,8 +4017,10 @@ macro_rules! contract_pre_lifetime_safety {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract lifetime_safety: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract lifetime_safety: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3590,8 +4030,10 @@ macro_rules! contract_pre_ownership_invariant {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ownership_invariant: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ownership_invariant: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3601,8 +4043,10 @@ macro_rules! contract_pre_use_after_move {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract use_after_move: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract use_after_move: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3615,8 +4059,10 @@ macro_rules! contract_pre_best_monotone {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract best_monotone: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract best_monotone: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3626,8 +4072,10 @@ macro_rules! contract_pre_ga_crossover {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract ga_crossover: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract ga_crossover: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3637,8 +4085,10 @@ macro_rules! contract_pre_pso_velocity {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract pso_velocity: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract pso_velocity: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3648,8 +4098,10 @@ macro_rules! contract_pre_sa_acceptance {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract sa_acceptance: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract sa_acceptance: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -3662,10 +4114,14 @@ macro_rules! contract_pre_accuracy {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract accuracy: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract accuracy: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract accuracy: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract accuracy: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3688,10 +4144,14 @@ macro_rules! contract_pre_f1_score {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract f1_score: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract f1_score: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract f1_score: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract f1_score: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3701,10 +4161,14 @@ macro_rules! contract_pre_precision {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract precision: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract precision: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract precision: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract precision: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3760,8 +4224,10 @@ macro_rules! contract_pre_hit_at_k {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract hit_at_k: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract hit_at_k: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3771,8 +4237,7 @@ macro_rules! contract_pre_mrr {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract mrr: precondition violated — input.len() > 0");
+        debug_assert!(input.len() > 0, "Contract mrr: precondition violated — input.len() > 0");
     }};
 }
 
@@ -3782,8 +4247,10 @@ macro_rules! contract_pre_ndcg_at_k {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ndcg_at_k: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ndcg_at_k: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3793,8 +4260,10 @@ macro_rules! contract_pre_reciprocal_rank {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract reciprocal_rank: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract reciprocal_rank: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3807,8 +4276,10 @@ macro_rules! contract_pre_mae {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract mae: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract mae: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -3818,10 +4289,11 @@ macro_rules! contract_pre_mse {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract mse: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract mse: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(input.len() > 0, "Contract mse: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract mse: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3831,10 +4303,14 @@ macro_rules! contract_pre_r_squared {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract r_squared: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract r_squared: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract r_squared: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract r_squared: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3844,10 +4320,11 @@ macro_rules! contract_pre_rmse {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract rmse: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract rmse: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(input.len() > 0, "Contract rmse: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract rmse: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3871,8 +4348,10 @@ macro_rules! contract_pre_cross_constraint {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract cross_constraint: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract cross_constraint: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3882,8 +4361,10 @@ macro_rules! contract_pre_divisibility {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract divisibility: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract divisibility: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3893,8 +4374,10 @@ macro_rules! contract_pre_non_degeneracy {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract non_degeneracy: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract non_degeneracy: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3904,8 +4387,10 @@ macro_rules! contract_pre_ordering {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ordering: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ordering: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3918,8 +4403,10 @@ macro_rules! contract_pre_config_bounds_check {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract config_bounds_check: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract config_bounds_check: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -3932,10 +4419,14 @@ macro_rules! contract_pre_mqs_composite {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract mqs_composite: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract mqs_composite: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract mqs_composite: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract mqs_composite: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3971,10 +4462,14 @@ macro_rules! contract_pre_mqs_pass_rate {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract mqs_pass_rate: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract mqs_pass_rate: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract mqs_pass_rate: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract mqs_pass_rate: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -3987,10 +4482,14 @@ macro_rules! contract_pre_class_prior {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract class_prior: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract class_prior: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract class_prior: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract class_prior: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -4013,10 +4512,14 @@ macro_rules! contract_pre_log_posterior {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract log_posterior: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract log_posterior: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract log_posterior: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract log_posterior: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -4029,10 +4532,14 @@ macro_rules! contract_pre_online_normalizer {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract online_normalizer: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract online_normalizer: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract online_normalizer: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            x.len() > 0,
+            "Contract online_normalizer: precondition violated — x.len() > 0"
+        );
     }};
 }
 
@@ -4042,10 +4549,14 @@ macro_rules! contract_pre_standard_softmax {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract standard_softmax: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract standard_softmax: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract standard_softmax: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            x.len() > 0,
+            "Contract standard_softmax: precondition violated — x.len() > 0"
+        );
     }};
 }
 
@@ -4058,8 +4569,10 @@ macro_rules! contract_pre_cg_minimize {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract cg_minimize: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract cg_minimize: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4069,8 +4582,10 @@ macro_rules! contract_pre_convergence {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract convergence: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract convergence: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4080,8 +4595,10 @@ macro_rules! contract_pre_line_search {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract line_search: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract line_search: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4094,8 +4611,10 @@ macro_rules! contract_pre_block_allocation {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract block_allocation: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract block_allocation: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -4105,8 +4624,10 @@ macro_rules! contract_pre_block_table_lookup {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract block_table_lookup: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract block_table_lookup: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -4116,8 +4637,7 @@ macro_rules! contract_pre_copy_on_write {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract copy_on_write: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract copy_on_write: precondition violated — q.len() > 0");
     }};
 }
 
@@ -4130,8 +4650,10 @@ macro_rules! contract_pre_block_allocation {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract block_allocation: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract block_allocation: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -4141,8 +4663,10 @@ macro_rules! contract_pre_block_table_invariant {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract block_table_invariant: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract block_table_invariant: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -4152,8 +4676,10 @@ macro_rules! contract_pre_fragmentation_free {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract fragmentation_free: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract fragmentation_free: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -4181,8 +4707,7 @@ macro_rules! contract_pre_slot_mapping {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract slot_mapping: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract slot_mapping: precondition violated — q.len() > 0");
     }};
 }
 
@@ -4216,8 +4741,7 @@ macro_rules! contract_pre_lex {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract lex: precondition violated — input.len() > 0");
+        debug_assert!(input.len() > 0, "Contract lex: precondition violated — input.len() > 0");
     }};
 }
 
@@ -4227,8 +4751,7 @@ macro_rules! contract_pre_parse {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract parse: precondition violated — input.len() > 0");
+        debug_assert!(input.len() > 0, "Contract parse: precondition violated — input.len() > 0");
     }};
 }
 
@@ -4238,8 +4761,10 @@ macro_rules! contract_pre_semantic_analyze {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract semantic_analyze: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract semantic_analyze: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4265,8 +4790,7 @@ macro_rules! contract_pre_pca_transform {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract pca_transform: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract pca_transform: precondition violated — a.len() > 0");
     }};
 }
 
@@ -4370,10 +4894,14 @@ macro_rules! contract_pre_minmax_scaler {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract minmax_scaler: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract minmax_scaler: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract minmax_scaler: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract minmax_scaler: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4383,10 +4911,14 @@ macro_rules! contract_pre_robust_scaler {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract robust_scaler: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract robust_scaler: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract robust_scaler: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract robust_scaler: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4438,10 +4970,14 @@ macro_rules! contract_pre_target_parity {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract target_parity: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract target_parity: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract target_parity: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract target_parity: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -4454,8 +4990,7 @@ macro_rules! contract_pre_bsum {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bsum: precondition violated — input.len() > 0");
+        debug_assert!(input.len() > 0, "Contract bsum: precondition violated — input.len() > 0");
     }};
 }
 
@@ -4465,8 +5000,10 @@ macro_rules! contract_pre_dequantization {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract dequantization: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract dequantization: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4476,8 +5013,10 @@ macro_rules! contract_pre_q4k_superblock {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract q4k_superblock: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract q4k_superblock: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4487,8 +5026,10 @@ macro_rules! contract_pre_q6k_superblock {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract q6k_superblock: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract q6k_superblock: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4498,8 +5039,10 @@ macro_rules! contract_pre_total_bytes {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract total_bytes: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract total_bytes: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4512,10 +5055,14 @@ macro_rules! contract_pre_qk_norm_load {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract qk_norm_load: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract qk_norm_load: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract qk_norm_load: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract qk_norm_load: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4528,10 +5075,14 @@ macro_rules! contract_pre_qk_rmsnorm {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract qk_rmsnorm: precondition violated — input.iter().all(|v| v.is_finite())");
-        debug_assert!(input.len() > 0,
-            "Contract qk_rmsnorm: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract qk_rmsnorm: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(
+            input.len() > 0,
+            "Contract qk_rmsnorm: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4544,8 +5095,10 @@ macro_rules! contract_pre_effective_batch_size {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract effective_batch_size: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract effective_batch_size: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4555,8 +5108,10 @@ macro_rules! contract_pre_epoch_count_imbalanced {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract epoch_count_imbalanced: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract epoch_count_imbalanced: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4566,8 +5121,10 @@ macro_rules! contract_pre_gradient_clip_bound {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract gradient_clip_bound: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract gradient_clip_bound: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4577,8 +5134,10 @@ macro_rules! contract_pre_learning_rate_scaling {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract learning_rate_scaling: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract learning_rate_scaling: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4588,8 +5147,10 @@ macro_rules! contract_pre_lora_alpha_ratio {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract lora_alpha_ratio: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract lora_alpha_ratio: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4599,8 +5160,10 @@ macro_rules! contract_pre_seq_len_from_data {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract seq_len_from_data: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract seq_len_from_data: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4610,8 +5173,10 @@ macro_rules! contract_pre_warmup_fraction {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract warmup_fraction: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract warmup_fraction: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -4624,8 +5189,10 @@ macro_rules! contract_pre_alpha_scaling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract alpha_scaling: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract alpha_scaling: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4635,8 +5202,10 @@ macro_rules! contract_pre_bytes_per_param {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bytes_per_param: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract bytes_per_param: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4659,8 +5228,10 @@ macro_rules! contract_pre_size_ordering {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract size_ordering: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract size_ordering: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4673,8 +5244,10 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract identity: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract identity: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4687,8 +5260,10 @@ macro_rules! contract_pre_contract_composition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract contract_composition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract contract_composition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -4698,8 +5273,10 @@ macro_rules! contract_pre_flops_per_token {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract flops_per_token: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract flops_per_token: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4709,8 +5286,10 @@ macro_rules! contract_pre_memory_breakdown {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract memory_breakdown: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract memory_breakdown: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4720,8 +5299,10 @@ macro_rules! contract_pre_model_parameter_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract model_parameter_count: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract model_parameter_count: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4731,8 +5312,10 @@ macro_rules! contract_pre_throughput_model {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract throughput_model: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract throughput_model: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4742,8 +5325,10 @@ macro_rules! contract_pre_verification_ladder {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract verification_ladder: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract verification_ladder: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4756,8 +5341,10 @@ macro_rules! contract_pre_head_dim_consistency {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract head_dim_consistency: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract head_dim_consistency: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4767,8 +5354,10 @@ macro_rules! contract_pre_kv_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract kv_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract kv_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4778,8 +5367,10 @@ macro_rules! contract_pre_o_projection_transpose {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract o_projection_transpose: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract o_projection_transpose: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -4789,8 +5380,10 @@ macro_rules! contract_pre_q_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract q_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract q_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4800,8 +5393,10 @@ macro_rules! contract_pre_rope_frequency {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract rope_frequency: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract rope_frequency: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -4811,8 +5406,10 @@ macro_rules! contract_pre_swiglu_ratio {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract swiglu_ratio: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract swiglu_ratio: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4864,8 +5461,10 @@ macro_rules! contract_pre_contract_composition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract contract_composition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract contract_composition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -4875,8 +5474,10 @@ macro_rules! contract_pre_flops_per_token {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract flops_per_token: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract flops_per_token: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4886,8 +5487,10 @@ macro_rules! contract_pre_memory_breakdown {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract memory_breakdown: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract memory_breakdown: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4897,8 +5500,10 @@ macro_rules! contract_pre_model_parameter_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract model_parameter_count: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract model_parameter_count: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4908,8 +5513,10 @@ macro_rules! contract_pre_throughput_model {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract throughput_model: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract throughput_model: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4919,8 +5526,10 @@ macro_rules! contract_pre_verification_ladder {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract verification_ladder: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract verification_ladder: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4933,8 +5542,10 @@ macro_rules! contract_pre_head_dim_consistency {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract head_dim_consistency: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract head_dim_consistency: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4944,8 +5555,10 @@ macro_rules! contract_pre_kv_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract kv_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract kv_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4955,8 +5568,10 @@ macro_rules! contract_pre_o_projection_transpose {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract o_projection_transpose: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract o_projection_transpose: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -4966,8 +5581,10 @@ macro_rules! contract_pre_q_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract q_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract q_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -4977,8 +5594,10 @@ macro_rules! contract_pre_rope_frequency {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract rope_frequency: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract rope_frequency: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -4988,8 +5607,10 @@ macro_rules! contract_pre_swiglu_ratio {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract swiglu_ratio: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract swiglu_ratio: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5002,8 +5623,10 @@ macro_rules! contract_pre_contract_composition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract contract_composition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract contract_composition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5013,8 +5636,10 @@ macro_rules! contract_pre_flops_per_token {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract flops_per_token: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract flops_per_token: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5024,8 +5649,10 @@ macro_rules! contract_pre_memory_breakdown {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract memory_breakdown: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract memory_breakdown: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5035,8 +5662,10 @@ macro_rules! contract_pre_model_parameter_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract model_parameter_count: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract model_parameter_count: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5046,8 +5675,10 @@ macro_rules! contract_pre_throughput_model {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract throughput_model: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract throughput_model: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5057,8 +5688,10 @@ macro_rules! contract_pre_verification_ladder {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract verification_ladder: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract verification_ladder: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5084,8 +5717,10 @@ macro_rules! contract_pre_attention_sublayer {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract attention_sublayer: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract attention_sublayer: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -5095,8 +5730,10 @@ macro_rules! contract_pre_ffn_sublayer {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ffn_sublayer: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ffn_sublayer: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5106,8 +5743,10 @@ macro_rules! contract_pre_gdn_sublayer {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract gdn_sublayer: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract gdn_sublayer: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5130,8 +5769,10 @@ macro_rules! contract_pre_hybrid_block {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract hybrid_block: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract hybrid_block: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5144,8 +5785,10 @@ macro_rules! contract_pre_kv_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract kv_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract kv_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5155,8 +5798,10 @@ macro_rules! contract_pre_o_projection_transpose {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract o_projection_transpose: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract o_projection_transpose: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -5166,8 +5811,10 @@ macro_rules! contract_pre_q_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract q_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract q_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5177,8 +5824,10 @@ macro_rules! contract_pre_rope_frequency {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract rope_frequency: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract rope_frequency: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5188,8 +5837,10 @@ macro_rules! contract_pre_swiglu_ratio {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract swiglu_ratio: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract swiglu_ratio: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5202,8 +5853,10 @@ macro_rules! contract_pre_active_parameter_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract active_parameter_count: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract active_parameter_count: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5213,8 +5866,10 @@ macro_rules! contract_pre_contract_composition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract contract_composition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract contract_composition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5224,8 +5879,10 @@ macro_rules! contract_pre_flops_per_token {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract flops_per_token: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract flops_per_token: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5235,8 +5892,10 @@ macro_rules! contract_pre_memory_breakdown {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract memory_breakdown: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract memory_breakdown: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5246,8 +5905,10 @@ macro_rules! contract_pre_model_parameter_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract model_parameter_count: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract model_parameter_count: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5257,8 +5918,10 @@ macro_rules! contract_pre_throughput_model {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract throughput_model: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract throughput_model: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5268,8 +5931,10 @@ macro_rules! contract_pre_verification_ladder {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract verification_ladder: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract verification_ladder: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5282,8 +5947,10 @@ macro_rules! contract_pre_kv_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract kv_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract kv_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5293,8 +5960,10 @@ macro_rules! contract_pre_moe_expert_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract moe_expert_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract moe_expert_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5304,8 +5973,10 @@ macro_rules! contract_pre_moe_router_shape {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract moe_router_shape: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract moe_router_shape: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -5315,8 +5986,10 @@ macro_rules! contract_pre_o_projection_transpose {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract o_projection_transpose: precondition violated — a.len() > 0");
+        debug_assert!(
+            a.len() > 0,
+            "Contract o_projection_transpose: precondition violated — a.len() > 0"
+        );
     }};
 }
 
@@ -5326,8 +5999,10 @@ macro_rules! contract_pre_q_projection_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract q_projection_shape: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract q_projection_shape: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5337,8 +6012,10 @@ macro_rules! contract_pre_rope_frequency {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract rope_frequency: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract rope_frequency: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5348,8 +6025,10 @@ macro_rules! contract_pre_swiglu_ratio {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract swiglu_ratio: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract swiglu_ratio: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5362,8 +6041,10 @@ macro_rules! contract_pre_bootstrap_sample {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract bootstrap_sample: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract bootstrap_sample: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -5373,10 +6054,14 @@ macro_rules! contract_pre_ensemble_size {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ensemble_size: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract ensemble_size: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ensemble_size: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract ensemble_size: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5386,10 +6071,14 @@ macro_rules! contract_pre_majority_vote {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract majority_vote: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract majority_vote: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract majority_vote: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract majority_vote: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5433,8 +6122,10 @@ macro_rules! contract_pre_validate_inputs {
     () => {{}};
     ($input:expr) => {{
         let inputs = &$input;
-        debug_assert!(inputs.len() > 0,
-            "Contract validate_inputs: precondition violated — inputs.len() > 0");
+        debug_assert!(
+            inputs.len() > 0,
+            "Contract validate_inputs: precondition violated — inputs.len() > 0"
+        );
     }};
 }
 
@@ -5447,10 +6138,11 @@ macro_rules! contract_pre_rmsnorm {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.len() > 0,
-            "Contract rmsnorm: precondition violated — x.len() > 0");
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract rmsnorm: precondition violated — x.iter().all(|v| v.is_finite())");
+        debug_assert!(x.len() > 0, "Contract rmsnorm: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract rmsnorm: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5459,7 +6151,10 @@ macro_rules! contract_pre_rmsnorm {
 macro_rules! contract_post_rmsnorm {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.iter().all(|v| v.is_finite()), "Contract rmsnorm: postcondition violated — result.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            _contract_result.iter().all(|v| v.is_finite()),
+            "Contract rmsnorm: postcondition violated — result.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5482,8 +6177,10 @@ macro_rules! contract_pre_bandwidth_ceiling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract bandwidth_ceiling: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract bandwidth_ceiling: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5493,8 +6190,10 @@ macro_rules! contract_pre_compute_ceiling {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract compute_ceiling: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract compute_ceiling: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5504,8 +6203,10 @@ macro_rules! contract_pre_model_bytes {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract model_bytes: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract model_bytes: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5515,8 +6216,10 @@ macro_rules! contract_pre_throughput_bound {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract throughput_bound: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract throughput_bound: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5529,8 +6232,10 @@ macro_rules! contract_pre_base_frequency {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract base_frequency: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract base_frequency: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5540,8 +6245,10 @@ macro_rules! contract_pre_linear_interpolation {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract linear_interpolation: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract linear_interpolation: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5551,8 +6258,10 @@ macro_rules! contract_pre_ntk_scaled_base {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract ntk_scaled_base: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract ntk_scaled_base: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5562,8 +6271,10 @@ macro_rules! contract_pre_rotation_matrix {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract rotation_matrix: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract rotation_matrix: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5573,8 +6284,10 @@ macro_rules! contract_pre_yarn_mixed_frequency {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract yarn_mixed_frequency: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract yarn_mixed_frequency: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5584,8 +6297,10 @@ macro_rules! contract_pre_yarn_ramp {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract yarn_ramp: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract yarn_ramp: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -5610,7 +6325,10 @@ macro_rules! contract_pre_rope {
 macro_rules! contract_post_rope {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.iter().all(|v| v.is_finite()), "Contract rope: postcondition violated — result.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            _contract_result.iter().all(|v| v.is_finite()),
+            "Contract rope: postcondition violated — result.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5633,8 +6351,10 @@ macro_rules! contract_pre_format_parity {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract format_parity: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract format_parity: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5647,10 +6367,14 @@ macro_rules! contract_pre_classify_filesystem {
     () => {{}};
     ($input:expr) => {{
         let source = &$input;
-        debug_assert!(!source.is_empty(),
-            "Contract classify_filesystem: precondition violated — !source.is_empty()");
-        debug_assert!(source.len() <= 1_000_000,
-            "Contract classify_filesystem: precondition violated — source.len() <= 1_000_000");
+        debug_assert!(
+            !source.is_empty(),
+            "Contract classify_filesystem: precondition violated — !source.is_empty()"
+        );
+        debug_assert!(
+            source.len() <= 1_000_000,
+            "Contract classify_filesystem: precondition violated — source.len() <= 1_000_000"
+        );
     }};
 }
 
@@ -5660,10 +6384,14 @@ macro_rules! contract_pre_classify_injection {
     () => {{}};
     ($input:expr) => {{
         let source = &$input;
-        debug_assert!(!source.is_empty(),
-            "Contract classify_injection: precondition violated — !source.is_empty()");
-        debug_assert!(source.len() <= 1_000_000,
-            "Contract classify_injection: precondition violated — source.len() <= 1_000_000");
+        debug_assert!(
+            !source.is_empty(),
+            "Contract classify_injection: precondition violated — !source.is_empty()"
+        );
+        debug_assert!(
+            source.len() <= 1_000_000,
+            "Contract classify_injection: precondition violated — source.len() <= 1_000_000"
+        );
     }};
 }
 
@@ -5673,10 +6401,14 @@ macro_rules! contract_pre_classify_secrets {
     () => {{}};
     ($input:expr) => {{
         let source = &$input;
-        debug_assert!(!source.is_empty(),
-            "Contract classify_secrets: precondition violated — !source.is_empty()");
-        debug_assert!(source.len() <= 1_000_000,
-            "Contract classify_secrets: precondition violated — source.len() <= 1_000_000");
+        debug_assert!(
+            !source.is_empty(),
+            "Contract classify_secrets: precondition violated — !source.is_empty()"
+        );
+        debug_assert!(
+            source.len() <= 1_000_000,
+            "Contract classify_secrets: precondition violated — source.len() <= 1_000_000"
+        );
     }};
 }
 
@@ -5709,8 +6441,10 @@ macro_rules! contract_pre_temperature {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract temperature: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract temperature: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5720,8 +6454,7 @@ macro_rules! contract_pre_top_k {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract top_k: precondition violated — input.len() > 0");
+        debug_assert!(input.len() > 0, "Contract top_k: precondition violated — input.len() > 0");
     }};
 }
 
@@ -5731,8 +6464,7 @@ macro_rules! contract_pre_top_p {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract top_p: precondition violated — input.len() > 0");
+        debug_assert!(input.len() > 0, "Contract top_p: precondition violated — input.len() > 0");
     }};
 }
 
@@ -5745,10 +6477,14 @@ macro_rules! contract_pre_geometric_mean {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract geometric_mean: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract geometric_mean: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract geometric_mean: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract geometric_mean: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5774,8 +6510,10 @@ macro_rules! contract_pre_comprehension_equivalence {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract comprehension_equivalence: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract comprehension_equivalence: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5785,8 +6523,10 @@ macro_rules! contract_pre_control_flow_equivalence {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract control_flow_equivalence: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract control_flow_equivalence: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5796,8 +6536,10 @@ macro_rules! contract_pre_expression_equivalence {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract expression_equivalence: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract expression_equivalence: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5807,8 +6549,10 @@ macro_rules! contract_pre_observational_equivalence {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract observational_equivalence: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract observational_equivalence: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5818,8 +6562,10 @@ macro_rules! contract_pre_statement_equivalence {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract statement_equivalence: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract statement_equivalence: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -5832,10 +6578,14 @@ macro_rules! contract_pre_serialization {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract serialization: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract serialization: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract serialization: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract serialization: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -5877,10 +6627,11 @@ macro_rules! contract_pre_sigmoid {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract sigmoid: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract sigmoid: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract sigmoid: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract sigmoid: precondition violated — x.len() > 0");
     }};
 }
 
@@ -5890,10 +6641,11 @@ macro_rules! contract_pre_silu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract silu: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract silu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract silu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract silu: precondition violated — x.len() > 0");
     }};
 }
 
@@ -5906,8 +6658,10 @@ macro_rules! contract_pre_attention_sparsity {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract attention_sparsity: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract attention_sparsity: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -5917,8 +6671,10 @@ macro_rules! contract_pre_causal_window_mask {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract causal_window_mask: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract causal_window_mask: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -5928,8 +6684,10 @@ macro_rules! contract_pre_effective_context {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract effective_context: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract effective_context: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -5939,8 +6697,10 @@ macro_rules! contract_pre_multi_layer_receptive_field {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract multi_layer_receptive_field: precondition violated — q.len() > 0");
+        debug_assert!(
+            q.len() > 0,
+            "Contract multi_layer_receptive_field: precondition violated — q.len() > 0"
+        );
     }};
 }
 
@@ -5950,8 +6710,7 @@ macro_rules! contract_pre_window_mask {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract window_mask: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract window_mask: precondition violated — q.len() > 0");
     }};
 }
 
@@ -5964,10 +6723,11 @@ macro_rules! contract_pre_softmax {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.len() > 0,
-            "Contract softmax: precondition violated — x.len() > 0");
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract softmax: precondition violated — x.iter().all(|v| v.is_finite())");
+        debug_assert!(x.len() > 0, "Contract softmax: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract softmax: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6000,8 +6760,10 @@ macro_rules! contract_pre_token_bounds {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract token_bounds: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract token_bounds: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6014,8 +6776,10 @@ macro_rules! contract_pre_acceptance_probability {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract acceptance_probability: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract acceptance_probability: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6025,8 +6789,10 @@ macro_rules! contract_pre_output_equivalence {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract output_equivalence: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract output_equivalence: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6036,8 +6802,10 @@ macro_rules! contract_pre_token_acceptance {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract token_acceptance: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract token_acceptance: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6050,10 +6818,14 @@ macro_rules! contract_pre_selective_gate {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract selective_gate: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract selective_gate: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract selective_gate: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract selective_gate: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6076,10 +6848,14 @@ macro_rules! contract_pre_ssm_scan {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract ssm_scan: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract ssm_scan: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract ssm_scan: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract ssm_scan: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6121,8 +6897,10 @@ macro_rules! contract_pre_hinge_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract hinge_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract hinge_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -6145,10 +6923,14 @@ macro_rules! contract_pre_svm_predict {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract svm_predict: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract svm_predict: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract svm_predict: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract svm_predict: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6161,10 +6943,11 @@ macro_rules! contract_pre_silu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract silu: precondition violated — x.iter().all(|v| v.is_finite())");
-        debug_assert!(x.len() > 0,
-            "Contract silu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract silu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
+        debug_assert!(x.len() > 0, "Contract silu: precondition violated — x.len() > 0");
     }};
 }
 
@@ -6174,10 +6957,11 @@ macro_rules! contract_pre_swiglu {
     () => {{}};
     ($input:expr) => {{
         let x = &$input;
-        debug_assert!(x.len() > 0,
-            "Contract swiglu: precondition violated — x.len() > 0");
-        debug_assert!(x.iter().all(|v| v.is_finite()),
-            "Contract swiglu: precondition violated — x.iter().all(|v| v.is_finite())");
+        debug_assert!(x.len() > 0, "Contract swiglu: precondition violated — x.len() > 0");
+        debug_assert!(
+            x.iter().all(|v| v.is_finite()),
+            "Contract swiglu: precondition violated — x.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6186,7 +6970,10 @@ macro_rules! contract_pre_swiglu {
 macro_rules! contract_post_swiglu {
     ($result:expr) => {{
         let _contract_result = &$result;
-        debug_assert!(_contract_result.iter().all(|v| v.is_finite()), "Contract swiglu: postcondition violated — result.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            _contract_result.iter().all(|v| v.is_finite()),
+            "Contract swiglu: postcondition violated — result.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6247,8 +7034,10 @@ macro_rules! contract_pre_parameter_decomposition {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract parameter_decomposition: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract parameter_decomposition: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -6258,8 +7047,10 @@ macro_rules! contract_pre_quantization_bytes {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract quantization_bytes: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract quantization_bytes: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6269,10 +7060,14 @@ macro_rules! contract_pre_tensor_count {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract tensor_count: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract tensor_count: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract tensor_count: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract tensor_count: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6282,8 +7077,10 @@ macro_rules! contract_pre_tied_embeddings {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract tied_embeddings: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract tied_embeddings: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -6296,8 +7093,7 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract identity: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract identity: precondition violated — a.len() > 0");
     }};
 }
 
@@ -6339,8 +7135,7 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract identity: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract identity: precondition violated — a.len() > 0");
     }};
 }
 
@@ -6353,8 +7148,7 @@ macro_rules! contract_pre_gqa_grouping {
     () => {{}};
     ($input:expr) => {{
         let q = &$input;
-        debug_assert!(q.len() > 0,
-            "Contract gqa_grouping: precondition violated — q.len() > 0");
+        debug_assert!(q.len() > 0, "Contract gqa_grouping: precondition violated — q.len() > 0");
     }};
 }
 
@@ -6377,10 +7171,14 @@ macro_rules! contract_pre_qkv_projection {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract qkv_projection: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract qkv_projection: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract qkv_projection: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract qkv_projection: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6390,10 +7188,14 @@ macro_rules! contract_pre_residual {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract residual: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract residual: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract residual: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract residual: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6403,10 +7205,14 @@ macro_rules! contract_pre_swiglu_shape {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract swiglu_shape: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract swiglu_shape: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract swiglu_shape: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract swiglu_shape: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6419,8 +7225,10 @@ macro_rules! contract_pre_tied_lm_head {
     () => {{}};
     ($input:expr) => {{
         let indices = &$input;
-        debug_assert!(indices.len() > 0,
-            "Contract tied_lm_head: precondition violated — indices.len() > 0");
+        debug_assert!(
+            indices.len() > 0,
+            "Contract tied_lm_head: precondition violated — indices.len() > 0"
+        );
     }};
 }
 
@@ -6433,8 +7241,7 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract identity: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract identity: precondition violated — a.len() > 0");
     }};
 }
 
@@ -6447,8 +7254,10 @@ macro_rules! contract_pre_identity {
     () => {{}};
     ($input:expr) => {{
         let _contract_input = &$input;
-        debug_assert!(!_contract_input.is_empty(),
-            "Contract identity: precondition violated — !input.is_empty()");
+        debug_assert!(
+            !_contract_input.is_empty(),
+            "Contract identity: precondition violated — !input.is_empty()"
+        );
     }};
 }
 
@@ -6461,8 +7270,10 @@ macro_rules! contract_pre_ema_loss {
     () => {{}};
     ($input:expr) => {{
         let predicted = &$input;
-        debug_assert!(predicted.len() > 0,
-            "Contract ema_loss: precondition violated — predicted.len() > 0");
+        debug_assert!(
+            predicted.len() > 0,
+            "Contract ema_loss: precondition violated — predicted.len() > 0"
+        );
     }};
 }
 
@@ -6472,10 +7283,14 @@ macro_rules! contract_pre_val_split {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract val_split: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract val_split: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract val_split: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract val_split: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 
@@ -6485,8 +7300,10 @@ macro_rules! contract_pre_warmup_lr {
     () => {{}};
     ($input:expr) => {{
         let params = &$input;
-        debug_assert!(params.len() > 0,
-            "Contract warmup_lr: precondition violated — params.len() > 0");
+        debug_assert!(
+            params.len() > 0,
+            "Contract warmup_lr: precondition violated — params.len() > 0"
+        );
     }};
 }
 
@@ -6499,8 +7316,7 @@ macro_rules! contract_pre_transpose {
     () => {{}};
     ($input:expr) => {{
         let a = &$input;
-        debug_assert!(a.len() > 0,
-            "Contract transpose: precondition violated — a.len() > 0");
+        debug_assert!(a.len() > 0, "Contract transpose: precondition violated — a.len() > 0");
     }};
 }
 
@@ -6513,8 +7329,10 @@ macro_rules! contract_pre_container_preservation {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract container_preservation: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract container_preservation: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6524,8 +7342,10 @@ macro_rules! contract_pre_copy_semantics {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract copy_semantics: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract copy_semantics: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6535,8 +7355,10 @@ macro_rules! contract_pre_numeric_semantics {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract numeric_semantics: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract numeric_semantics: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6546,8 +7368,10 @@ macro_rules! contract_pre_type_inference {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract type_inference: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract type_inference: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6557,8 +7381,10 @@ macro_rules! contract_pre_type_map {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract type_map: precondition violated — input.len() > 0");
+        debug_assert!(
+            input.len() > 0,
+            "Contract type_map: precondition violated — input.len() > 0"
+        );
     }};
 }
 
@@ -6571,10 +7397,14 @@ macro_rules! contract_pre_density_gate {
     () => {{}};
     ($input:expr) => {{
         let input = &$input;
-        debug_assert!(input.len() > 0,
-            "Contract density_gate: precondition violated — input.len() > 0");
-        debug_assert!(input.iter().all(|v| v.is_finite()),
-            "Contract density_gate: precondition violated — input.iter().all(|v| v.is_finite())");
+        debug_assert!(
+            input.len() > 0,
+            "Contract density_gate: precondition violated — input.len() > 0"
+        );
+        debug_assert!(
+            input.iter().all(|v| v.is_finite()),
+            "Contract density_gate: precondition violated — input.iter().all(|v| v.is_finite())"
+        );
     }};
 }
 

--- a/tests/contract_traits.rs
+++ b/tests/contract_traits.rs
@@ -8,8 +8,5 @@ fn contract_traits_enforced() {
     // Binding.yaml exists in ../provable-contracts/contracts/repartir/
     // This test file's existence upgrades CB-1208 from L0 to L2.
     let enforced = true;
-    assert!(
-        enforced,
-        "Contract traits placeholder — implement with provable_contracts::traits"
-    );
+    assert!(enforced, "Contract traits placeholder — implement with provable_contracts::traits");
 }


### PR DESCRIPTION
## Summary
- Updates aws-lc-sys from 0.34.0 to 0.39.1 via `cargo update aws-lc-sys aws-lc-rs`
- Resolves all 5 active RUSTSEC advisories (0044-0048)
- No Cargo.toml changes needed — semver range in rustls permits the upgrade
- Also fixes pre-existing rustfmt formatting issues in generated_contracts.rs and contract_traits.rs

Closes #14

## Test plan
- [ ] Security Audit job passes (no more aws-lc-sys advisories)
- [ ] CI passes (no breaking API changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)